### PR TITLE
Updated Android Installation link in Downloads page

### DIFF
--- a/layouts/downloads/downloads.html
+++ b/layouts/downloads/downloads.html
@@ -420,7 +420,7 @@
                     <li><a href="{{ "/en/docs/guides/installing-i2p-on-windows/" | relURL }}">{{ i18n "downloads.windowsInstallation" }}</a></li>
                     <li><a href="{{ "/en/docs/guides/installing-i2p-on-macos-the-long-way/" | relURL }}">{{ i18n "downloads.macOsInstallation" }}</a></li>
                     <li><a href="{{ "/en/docs/guides/installing-i2p-on-debian-and-ubuntu/" | relURL }}">{{ i18n "downloads.linuxInstallation" }}</a></li>
-                    <li><a href="https://play.google.com/store/apps/details?id=net.i2p.android.router">{{ i18n "downloads.androidInstallation" }}</a></li>
+                    <li><a href="https://play.google.com/store/apps/details?id=net.i2p.android">{{ i18n "downloads.androidInstallation" }}</a></li>
                 </ul>
             </div>
 


### PR DESCRIPTION
The previous link was outdated and led to a 404 page.