### PR TITLE
fix: remove blank lines triggering Goldmark code blocks in papers BibTeX

### DIFF
--- a/content/ar/papers/_index.md
+++ b/content/ar/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/cs/papers/_index.md
+++ b/content/cs/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/de/papers/_index.md
+++ b/content/de/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/en/papers/_index.md
+++ b/content/en/papers/_index.md
@@ -130,7 +130,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -156,7 +155,6 @@ type: "papers"
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development
         (INDIACom), April 2024.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -202,7 +200,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications, 2021.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -709,7 +706,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -774,7 +770,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -799,7 +794,6 @@ type: "papers"
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology
         (ICIT), March 2016.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -890,7 +884,6 @@ type: "papers"
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing
         (ICAC), September 2016.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -1146,7 +1139,6 @@ type: "papers"
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20), 2014, pages 7333-7345.
     </div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1294,7 +1286,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1546,7 +1537,6 @@ type: "papers"
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St.
         Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1743,7 +1733,6 @@ type: "papers"
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et
         sociales, 2009.</div>
     <div class="paper-actions">
-
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/es/papers/_index.md
+++ b/content/es/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/fr/papers/_index.md
+++ b/content/fr/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/hi/papers/_index.md
+++ b/content/hi/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/ko/papers/_index.md
+++ b/content/ko/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/pt/papers/_index.md
+++ b/content/pt/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/ru/papers/_index.md
+++ b/content/ru/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/tr/papers/_index.md
+++ b/content/tr/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/vi/papers/_index.md
+++ b/content/vi/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,

--- a/content/zh/papers/_index.md
+++ b/content/zh/papers/_index.md
@@ -93,7 +93,6 @@ type: "papers"
     <div class="paper-authors">Jacques Bou Abdo and Liaquat Hossain</div>
     <div class="paper-venue">In the Complex Networks and their Applications XII, February 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{abdo,
@@ -114,7 +113,6 @@ type: "papers"
     <div class="paper-authors">Tashi Wangchuk, Ngaira Mandela, Tumaini Mbinda, Kamboisssoi Damedjate, Felix Etyang, and Joel Makopa</div>
     <div class="paper-venue">In the 2024 11th International Conference on Computing for Sustainable Global Development (INDIACom), April 2024.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wangchuk,
@@ -140,7 +138,6 @@ type: "papers"
     <div class="paper-authors">Yu Chih-Wei</div>
     <div class="paper-venue">Ph.D. thesis, Beijing University of Posts and Telecommunications,  2021.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@phdthesis{yu2021,
@@ -604,7 +601,6 @@ type: "papers"
     <div class="paper-authors">Wilson Bazli and Hurst</div>
     <div class="paper-venue">In System Science & Control Engeneering 2017(5), June 2017, pages 278-286.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{bazli2017-the-dark-side-of-i2p,
@@ -663,7 +659,6 @@ type: "papers"
     <div class="paper-authors">Hamish Haughey, Gregory Epiphaniou, and Haider M. Al-Khateeb</div>
     <div class="paper-venue">In Network Security 2016(3), March 2016, pages 10-18.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{haughey2016,
@@ -685,7 +680,6 @@ type: "papers"
     <div class="paper-authors">Afzaal Ali, Maria Khan, Muhammad Saddique, Umar Pirzada, Muhammad Zohaib, Imran Ahmad, and Narayan Debnath</div>
     <div class="paper-venue">In the Proceedings of the 2016 IEEE International Conference on Industrial Technology (ICIT), March 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{ali2016,
@@ -766,7 +760,6 @@ type: "papers"
     <div class="paper-authors">Maxim Wilson and Behnam Bazli</div>
     <div class="paper-venue">In the Proceedings of the 2016 22nd International Conference on Automation and Computing (ICAC), September 2016.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{wilson2016,
@@ -990,7 +983,6 @@ type: "papers"
     <div class="paper-authors">A. Karthigeyan, M. Robinson Joel, S. P. Manikandan, P. Raja Guru, and Sri Raman</div>
     <div class="paper-venue">In International Journal of Applied Engineering Research 9(20),  2014, pages 7333-7345.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{karthigeyan2014,
@@ -1127,7 +1119,6 @@ type: "papers"
     <div class="paper-authors">Xue Bin Wang, Pei Peng Liu, Cheng Long Li, and Qing Feng Tan</div>
     <div class="paper-venue">In Applied Mechanics and Materials 427-429, September 2013, pages 2223-2228.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@article{wang2013,
@@ -1354,7 +1345,6 @@ type: "papers"
     <div class="paper-authors">Bassam Zantout and Ramzi Haraty</div>
     <div class="paper-venue">In the Proceedings of ICN 2011, The Tenth International Conference on Networks, St. Maarten, The Netherlands Antilles, January 2011.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@inproceedings{zantout2011,
@@ -1525,7 +1515,6 @@ type: "papers"
     <div class="paper-authors">Laurie Delmer</div>
     <div class="paper-venue">Masters's thesis, Université catholique de Louvain - Département des sciences politiques et sociales,  2009.</div>
     <div class="paper-actions">
-        
         <div class="bibtex-wrapper">
             <button class="bibtex-toggle">Show BibTeX</button>
             <div class="bibtex-content">@mastersthesis{delmer-mthesis,


### PR DESCRIPTION
Blank lines between `<div class="paper-actions">` and indented
`<div class="bibtex-wrapper">` caused Hugo Goldmark renderer to
treat the BibTeX HTML as a Markdown code block, wrapping it in
`<pre><code>` and displaying raw HTML source instead of interactive
BibTeX toggle buttons.

This affected 11 papers across all 13 languages — papers without
PDF download links before the BibTeX section. The fix removes the
blank line so the indented HTML flows directly from the parent div
and is not reinterpreted as a code block.

**Before:** `<pre><code>&lt;div class="bibtex-wrapper"&gt;...</code></pre>`
**After:** `<button class="bibtex-toggle">Show BibTeX</button>` (working)

13 files changed, 143 deletions (11 blank lines × 13 languages).